### PR TITLE
Add basic Makefile for building on UNIX systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.vcxproj
 *.vcxproj.filters
 *.vcxproj.user
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+CC=g++
+LD=g++
+
+CFLAGS=
+LFLAGS=-lGL -lglfw -lGLEW
+
+SRC=$(shell find . -name \*.cpp)
+OBJ=${SRC:.cpp=.o}
+
+OUT=chromaray
+
+all: options build
+
+options:
+	@echo CC 	= ${CC}
+	@echo LD 	= ${LD}
+	@echo CFLAGS 	= ${CFLAGS}
+	@echo LFLAGS 	= ${LFLAGS}
+	@echo SRC 	= ${SRC}
+	@echo OBJ 	= ${OBJ}
+
+.cpp.o:
+	${CC} -c $< ${CFLAGS} -o $@
+
+build: ${OBJ}
+	${LD} ${OBJ} -o ${OUT} ${LFLAGS}
+
+clean:
+	rm ${OBJ} -f
+	rm ${OUT} -f


### PR DESCRIPTION
This commit adds a [Makefile](https://en.wikipedia.org/wiki/Make_(software)) for building on Unix-like systems.
Windows users can also use this Makefile if they have Mingw or Cygwin installed.

I also appended `*.o` to the .gitignore file because the Makefile generates .o (object) files as part of the build process.