### PR TITLE
Fix Matrix Uniform bug

### DIFF
--- a/src/chromaray.hpp
+++ b/src/chromaray.hpp
@@ -1,6 +1,13 @@
 #pragma once
 
 #include <string>
+#include <iostream>
+#include <GL/glew.h>
+
+// GL error debugging
+#define GLCALL(x) x; clearGLerror(__FILE__, __LINE__)
+static const char* convertGLerrorToString(const GLenum error);
+static void clearGLerror(const char* file, int line);
 
 namespace Constants {
 	const int WINDOW_WIDTH = 640;
@@ -15,4 +22,36 @@ namespace Constants {
 	const float SCENE_FOV = 75.0f;
 	const float SCENE_NEARPLANE = 0.001f;
 	const float SCENE_FARPLANE = 100.0f;
+}
+
+static const char* convertGLerrorToString(const GLenum error) {
+	switch (error) {
+		case GL_INVALID_ENUM:
+			return "GL_INVALID_ENUM";
+			break;
+		case GL_INVALID_VALUE:
+			return "GL_INVALID_VALUE";
+			break;
+		case GL_INVALID_OPERATION:
+			return "GL_INVALID_OPERATION";
+			break;
+		case GL_STACK_OVERFLOW:
+			return "GL_STACK_OVERFLOW";
+			break;
+		case GL_STACK_UNDERFLOW:
+			return "GL_STACK_UNDERFLOW";
+			break;
+		case GL_OUT_OF_MEMORY:
+			return "GL_OUT_OF_MEMORY";
+			break;
+		default:
+			return "UNKNOWN";
+	}
+}
+
+static void clearGLerror(const char* file, int line) {
+	GLenum error;
+	while ((error = glGetError()) != GL_NO_ERROR) {
+		printf("GL ERROR [%s:%i]: %x (%s)\n", file, line, error, convertGLerrorToString(error));
+	}
 }

--- a/src/gfx/Model.cpp
+++ b/src/gfx/Model.cpp
@@ -1,5 +1,7 @@
 #include "Model.hpp"
 
+#include "../chromaray.hpp"
+
 Model::Model(std::vector<float> vertices, std::vector<unsigned> indices)
 	: m_VertexCount(indices.size()), 
 	m_VertexBuffer(vertices.data(), vertices.size() * sizeof(float)), 
@@ -11,7 +13,7 @@ Model::Model(std::vector<float> vertices, std::vector<unsigned> indices)
 
 void Model::draw() {
 	bind();
-	glDrawElements(GL_TRIANGLES, m_VertexCount, GL_UNSIGNED_INT, nullptr);
+	GLCALL(glDrawElements(GL_TRIANGLES, m_VertexCount, GL_UNSIGNED_INT, nullptr));
 	unbind();
 }
 

--- a/src/gfx/Shader.cpp
+++ b/src/gfx/Shader.cpp
@@ -29,11 +29,11 @@ void Shader::bindAttribute(unsigned pointer, const char* name) const {
 }
 
 unsigned Shader::getUniformLocation(const char* name) const {
-	return glGetUniformLocation(m_ID, name);
+	return GLCALL(glGetUniformLocation(m_ID, name));
 }
 
 void Shader::setMatrixUniform(Matrix4f matrix, const char* locationName) const {
-	glUniformMatrix4fv(getUniformLocation(locationName), 4 * 4, false, matrix.data[0]);
+	GLCALL(glUniformMatrix4fv(getUniformLocation(locationName), 1, false, (const float*)&matrix.data));
 }
 
 void Shader::use() const {


### PR DESCRIPTION
I also added a basic OpenGL debugging macro: `GLCALL(x)`, this will allow for easier debugging of OpenGL code if we wrap all of our raw opengl function calls with `GLCALL(glFunctionHere(...))`